### PR TITLE
Add article creation guide and ignore readme markdown

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,3 +1,5 @@
 All development must be done from the `develop` branch, never directly on `master`.
 
 `master` is built/deployed via CircleCI from `develop`; see `.circleci/config.yml` (the `if [ $CIRCLE_BRANCH == 'develop' ]` block that runs `npm run build` and pushes to `master`).
+
+For new article steps, see [readme.md](./readme.md).

--- a/blah.js
+++ b/blah.js
@@ -82,7 +82,8 @@ for (const f of files) {
   const base = basename(f)
   if (f === 'blah.js') continue
   if (f === 'motif.js') continue
-  if (['agents.md', 'readme.md'].includes(base.toLowerCase())) continue
+  if (f === 'agents.md') continue
+  if (f === 'readme.md') continue
   if (f.startsWith('server-fonts/')) continue
   if (f.startsWith('dist/')) continue
 

--- a/blah.js
+++ b/blah.js
@@ -82,7 +82,7 @@ for (const f of files) {
   const base = basename(f)
   if (f === 'blah.js') continue
   if (f === 'motif.js') continue
-  if (base.toLowerCase() === 'agents.md') continue
+  if (['agents.md', 'readme.md'].includes(base.toLowerCase())) continue
   if (f.startsWith('server-fonts/')) continue
   if (f.startsWith('dist/')) continue
 

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,8 @@
+# Creating a new article
+
+1. Copy `a-draft.md` to a new file named `<slug>.md` (example: `my-new-article.md`).
+2. Update frontmatter (`title`, `date`, optional `tags`, optional `layout`, optional `redirect`).
+3. Replace the draft body with your article content.
+4. For typical articles, skip local build checks; generation happens on push.
+5. For typical articles, skip local output checks (HTML/social image/sitemap); these are handled on push.
+6. Commit and push the new `.md` file.

--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,5 @@ Source and static site generator for dtrejo.com. See blah.js for article generat
 4. For typical articles, skip local build checks; generation happens on push.
 5. For typical articles, skip local output checks (HTML/social image/sitemap); these are handled on push.
 6. Commit and push the new `.md` file.
+7. CCI rebuilds and publishes site to `main`, github pages displays it within a minute or two.
+8. Done!

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,7 @@
-# Creating a new article
+# dtrejo.com
+Source and static site generator for dtrejo.com. See blah.js for article generation code and motif.js for social image generation code.
+
+## Creating a new article
 
 1. Copy `a-draft.md` to a new file named `<slug>.md` (example: `my-new-article.md`).
 2. Update frontmatter (`title`, `date`, optional `tags`, optional `layout`, optional `redirect`).


### PR DESCRIPTION
This pull request primarily adds documentation to clarify the process for creating new articles and updates file handling logic in `blah.js` to improve article generation. The most important changes are summarized below.

**Documentation improvements:**

* Added a new `readme.md` file with step-by-step instructions for creating a new article and an overview of the codebase.
* Updated `agents.md` to reference the new article creation steps in `readme.md`.

**File handling logic updates:**

* Modified `blah.js` to exclude both `agents.md` and `readme.md` (by filename, not just basename) from processing, ensuring these documentation files are not treated as articles.